### PR TITLE
quick fix voting_verified finalization

### DIFF
--- a/ride/factory_v2.ride
+++ b/ride/factory_v2.ride
@@ -864,7 +864,7 @@ func onVerificationLoss(assetId: String) = {
     unit
     
   }
-  strict actions = FOLD<13>(priceAssets, unit, cb)
+  strict actions = FOLD<20>(priceAssets, unit, cb)
 
   (nil, unit)
 }


### PR DESCRIPTION
`onVerificationLoss` is called on voting finalization 
Price asset list could contain more than 13 ids